### PR TITLE
EntitySync: Move thread creation

### DIFF
--- a/api/AltV.Net.EntitySync/EntityThread.cs
+++ b/api/AltV.Net.EntitySync/EntityThread.cs
@@ -83,8 +83,6 @@ namespace AltV.Net.EntitySync
                 throw new ArgumentException("onEntityPositionChange should not be null.");
             }
 
-            thread = new Thread(OnLoop) {IsBackground = true};
-            thread.Start();
             this.entityThreadRepository = entityThreadRepository;
             this.clientThreadRepository = clientThreadRepository;
             this.spatialPartition = spatialPartition;
@@ -94,6 +92,9 @@ namespace AltV.Net.EntitySync
             this.onEntityDataChange = onEntityDataChange;
             this.onEntityPositionChange = onEntityPositionChange;
             this.onEntityClearCache = onEntityClearCache;
+
+            thread = new Thread(OnLoop) { IsBackground = true };
+            thread.Start();
         }
 
         public void OnLoop()


### PR DESCRIPTION
Throws occasionally nullreference exception in OnLoop if thread starts too fast